### PR TITLE
Make site name, URL and icon in generated HTML configurable

### DIFF
--- a/static/templates/meta_tags.html.ejs
+++ b/static/templates/meta_tags.html.ejs
@@ -1,7 +1,3 @@
   <link rel="alternate" type="application/json+oembed"
         href="<%=deploy_url%>oembed.json"
         title="<%=config.headline || project.title%>" />
-
-  <link rel="canonical" href="https://www.vox.com" />
-
-  <link rel="shortcut icon" href="https://cdn3.vox-cdn.com/community_logos/52517/voxv.png" />

--- a/static/templates/oembed.json.ejs
+++ b/static/templates/oembed.json.ejs
@@ -1,8 +1,6 @@
 {
 "version": "1.0",
 "type": "rich",
-"provider_name": "Vox Media",
-"provider_url": "https://www.voxmedia.com",
 "title": "<%=config.headline || project.title%>",
 "author_name": "<%=config.credit%>",
 "html": "<%=embed_code.replace(/"/g, '\\"')%>",


### PR DESCRIPTION
There's the tiniest bit of Vox-specific markup in the generated HTML and in the oEmbed response. This PR drops these elements from the included templates.

FWIW, it looks like `provider_url` and `provider_name` are marked as optional in the oEmbed docs, so I _think_ it's safe to remove them (see 2.3.4 @ https://oembed.com/).

I also considered an option that allowed for some custom HTML to be dropped in the `.vizappconfig` file and inserted during render and would be happy to do a PR for that instead if that interests you.